### PR TITLE
lua: fix test logging

### DIFF
--- a/tests/lua/test.sh
+++ b/tests/lua/test.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR="$(cd "$(dirname "$0" )" && pwd)"
 
 ulimit -s 16384 # debug build requires this much stack to pass tests
 (cd "$SCRIPT_DIR/repo/testes" && \
-    cargo run -- -e_U=true all.lua 2>&1 \
-    | tee `basename "$0"`.log)
+    cargo run -- -e_U=true all.lua 2>&1 ) \
+    | tee `basename "$0"`.log


### PR DESCRIPTION
The .log file must be generated in the `tests/lua` directory.