### PR TITLE
tests: explicitly enable `reorganize_definitions` for all tests

### DIFF
--- a/tests/curl/conf.yml
+++ b/tests/curl/conf.yml
@@ -1,30 +1,30 @@
 requirements:
-    ubuntu:
-        apt:
-            packages:
-                - libbrotli-dev
-                - libidn2-dev
-                - libldap2-dev
-                - libnghttp2-dev
-                - libpsl-dev
-                - librtmp-dev
-                - libzstd-dev
+  ubuntu:
+    apt:
+      packages:
+        - libbrotli-dev
+        - libidn2-dev
+        - libldap2-dev
+        - libnghttp2-dev
+        - libpsl-dev
+        - librtmp-dev
+        - libzstd-dev
 
 transpile:
-    autogen: true
-    # tflags: --reorganize-definitions
-    binary: tool_main
+  autogen: true
+  # tflags: --reorganize-definitions
+  binary: tool_main
 
 refactor:
-    autogen: true
-    transforms:
-        - remove_unused_labels
-        - remove_literal_suffixes
-        - convert_cast_as_ptr
-        - remove_unnecessary_refs
+  autogen: true
+  transforms:
+    - remove_unused_labels
+    - remove_literal_suffixes
+    - convert_cast_as_ptr
+    - remove_unnecessary_refs
 
 cargo.transpile:
-    autogen: true
+  autogen: true
 
 cargo.refactor:
-    autogen: true
+  autogen: true

--- a/tests/curl/conf.yml
+++ b/tests/curl/conf.yml
@@ -12,12 +12,14 @@ requirements:
 
 transpile:
   autogen: true
-  # tflags: --reorganize-definitions
+  tflags: --reorganize-definitions --disable-refactoring
   binary: tool_main
 
 refactor:
   autogen: true
   transforms:
+    - rename_unnamed
+    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/libmcs/conf.yml
+++ b/tests/libmcs/conf.yml
@@ -1,9 +1,12 @@
 transpile:
   autogen: true
+  tflags: --reorganize-definitions --disable-refactoring
 
 refactor:
   autogen: true
   transforms:
+    - rename_unnamed
+    - reorganize_definitions
     - remove_unused_labels
 
 cargo.transpile:

--- a/tests/libxml2/conf.yml
+++ b/tests/libxml2/conf.yml
@@ -19,6 +19,7 @@ refactor:
   - remove_unnecessary_refs
   - remove_literal_suffixes
   - noop
+
 cargo.transpile:
   autogen: true
 

--- a/tests/nginx/conf.yml
+++ b/tests/nginx/conf.yml
@@ -14,13 +14,14 @@ cargo.refactor:
 
 transpile:
   autogen: true
-  # blocked on https://github.com/immunant/c2rust/issues/266
-  # tflags: --reorganize-definitions
+  tflags: --reorganize-definitions --disable-refactoring
   binary: nginx
 
 refactor:
   autogen: true
   transforms:
+    - rename_unnamed
+    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/nginx/conf.yml
+++ b/tests/nginx/conf.yml
@@ -5,6 +5,7 @@ requirements:
         - libgcrypt20
         - libpcre3-dev
         - zlib1g-dev
+
 cargo.transpile:
   autogen: true
 

--- a/tests/python2/conf.yml
+++ b/tests/python2/conf.yml
@@ -17,11 +17,14 @@ requirements:
 
 transpile:
   autogen: true
+  tflags: --reorganize-definitions --disable-refactoring
   binary: python
 
 refactor:
   autogen: true
   transforms:
+    - rename_unnamed
+    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/redis/conf.yml
+++ b/tests/redis/conf.yml
@@ -1,5 +1,6 @@
 transpile:
   autogen: true
+  tflags: --reorganize-definitions --disable-refactoring
   binary: redis-server
 
   # needs support for __atomic_*
@@ -8,6 +9,8 @@ transpile:
 refactor:
   autogen: true
   transforms:
+    - rename_unnamed
+    - reorganize_definitions
     - remove_literal_suffixes
     - convert_cast_as_ptr
     - remove_unnecessary_refs

--- a/tests/ruby/conf.yml
+++ b/tests/ruby/conf.yml
@@ -11,7 +11,7 @@ transpile:
   autogen: true
   tflags: --reorganize-definitions --disable-refactoring
   binary: ruby
-#  cflags: "-O0"
+  # cflags: "-O0"
 
 refactor:
   autogen: true

--- a/tests/zstd/conf.yml
+++ b/tests/zstd/conf.yml
@@ -12,7 +12,7 @@ transpile:
 
 refactor:
   # TODO: re-enable once c2rust-refactor supports asm!
-  #autogen: true
+  # autogen: true
   transforms:
     - rename_unnamed
     - reorganize_definitions


### PR DESCRIPTION
Now that https://github.com/immunant/c2rust/pull/1455 merged, enable `reorganize_definitions` explicitly (as opposed to implicitly through https://github.com/immunant/c2rust/pull/1451, which we don't want to do because `c2rust-refactor` isn't installed by default since it doesn't build on `stable`).