### PR TITLE
Add index to name of refactor diff files to keep track of order of application

### DIFF
--- a/tests/templates.py
+++ b/tests/templates.py
@@ -63,9 +63,16 @@ ARTIFACT_DIR="${ARTIFACT_ROOT}/${PROJECT_NAME}"
 rm -rf "$ARTIFACT_DIR"
 mkdir -p "$ARTIFACT_DIR"
 
+diff_idx=0
 while IFS= read -r transform; do
     [[ -z "$transform" ]] && continue
-    DIFF_FILE="$ARTIFACT_DIR/${transform}.diff"
+
+    # Print the index in 4 digit format with leading zeroes,
+    # so the indices align just like in git outputs
+    diff_idx4=`printf "%04d" "${diff_idx}"`
+    : $((diff_idx++))
+
+    DIFF_FILE="$ARTIFACT_DIR/${diff_idx4}_${transform}.diff"
 
     c2rust-refactor \
         ${transform} \


### PR DESCRIPTION
The order which we apply the transforms in is relevant, so prepend an index to the diff name. This follows the style of git patches: `0000_first_patch.diff`, `0001_second_patch.diff`, etc...