### PR TITLE
Revert the commit that enabled reorganize_definitions on all tests

### DIFF
--- a/tests/curl/conf.yml
+++ b/tests/curl/conf.yml
@@ -12,14 +12,12 @@ requirements:
 
 transpile:
   autogen: true
-  tflags: --reorganize-definitions --disable-refactoring
+  # tflags: --reorganize-definitions
   binary: tool_main
 
 refactor:
   autogen: true
   transforms:
-    - rename_unnamed
-    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/libmcs/conf.yml
+++ b/tests/libmcs/conf.yml
@@ -1,12 +1,9 @@
 transpile:
   autogen: true
-  tflags: --reorganize-definitions --disable-refactoring
 
 refactor:
   autogen: true
   transforms:
-    - rename_unnamed
-    - reorganize_definitions
     - remove_unused_labels
 
 cargo.transpile:

--- a/tests/nginx/conf.yml
+++ b/tests/nginx/conf.yml
@@ -14,14 +14,13 @@ cargo.refactor:
 
 transpile:
   autogen: true
-  tflags: --reorganize-definitions --disable-refactoring
+  # blocked on https://github.com/immunant/c2rust/issues/266
+  # tflags: --reorganize-definitions
   binary: nginx
 
 refactor:
   autogen: true
   transforms:
-    - rename_unnamed
-    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/python2/conf.yml
+++ b/tests/python2/conf.yml
@@ -17,14 +17,11 @@ requirements:
 
 transpile:
   autogen: true
-  tflags: --reorganize-definitions --disable-refactoring
   binary: python
 
 refactor:
   autogen: true
   transforms:
-    - rename_unnamed
-    - reorganize_definitions
     - remove_unused_labels
     - remove_literal_suffixes
     - convert_cast_as_ptr

--- a/tests/redis/conf.yml
+++ b/tests/redis/conf.yml
@@ -1,6 +1,5 @@
 transpile:
   autogen: true
-  tflags: --reorganize-definitions --disable-refactoring
   binary: redis-server
 
   # needs support for __atomic_*
@@ -9,8 +8,6 @@ transpile:
 refactor:
   autogen: true
   transforms:
-    - rename_unnamed
-    - reorganize_definitions
     - remove_literal_suffixes
     - convert_cast_as_ptr
     - remove_unnecessary_refs


### PR DESCRIPTION
https://github.com/immunant/c2rust/pull/1462/, https://github.com/immunant/c2rust/pull/1472 fixed the version mismatch that was hiding a ton of errors, so it wasn't until that merged that all of these `reorganize_definitions` enablements started having visible errors.  So for now, revert it, and we'll fix them one-by-one.