### PR TITLE
Run lua tests in release mode

### DIFF
--- a/tests/lua/test.sh
+++ b/tests/lua/test.sh
@@ -5,5 +5,5 @@ SCRIPT_DIR="$(cd "$(dirname "$0" )" && pwd)"
 
 ulimit -s 16384 # debug build requires this much stack to pass tests
 (cd "$SCRIPT_DIR/repo/testes" && \
-    cargo run -- -e_U=true all.lua 2>&1 ) \
+    cargo run --release -- -e_U=true all.lua 2>&1 ) \
     | tee `basename "$0"`.log


### PR DESCRIPTION
The lua test occasionally crashes with stack overflows. Build and run it in release mode so the compiler optimizes a lot of the stack variables away.